### PR TITLE
Update CI workflows with permissions and gh-extension-precompile version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Go Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v2
+      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd # v2.0.0
         with:
           generate_attestations: true
           go_version_file: go.mod


### PR DESCRIPTION
Adjust CI workflows to include permissions for content access and specify a fixed version for the `gh-extension-precompile` action.