### PR TITLE
Update CI workflow and enhance README with Tic Tac Toe instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   pull_request:
     branches: [ main ]
+  push: 
+    branches: [ main ]
   
 
 jobs:
@@ -17,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23' # You can change this to your desired Go version
+          go-version: '1.24' # You can change this to your desired Go version
 
       - name: Build
         run: go build -v ./...

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ gh game cointoss heads  # or tails
 
 The game will continue as long as you keep guessing correctly, allowing you to build up a streak. You can quit at any time by selecting "Quit" when prompted for your next guess.
 
+### Tic Tac Toe
+
+Play the classic game of Tic Tac Toe against another player. Players take turns placing X's and O's on a 3x3 grid, trying to get three in a row horizontally, vertically, or diagonally.
+
+```sh
+gh game tictactoe
+```
+
+The game provides an interactive interface where you can select positions on the board using numbers 1-9, corresponding to the grid positions from left to right, top to bottom.
+
 ### Whoami
 
 Display information about the currently authenticated GitHub user.


### PR DESCRIPTION
Add push permissions to the CI workflow and upgrade the Go version to 1.24. Include instructions for playing Tic Tac Toe in the README.