### PR TITLE
Extend rockpaperscissors

### DIFF
--- a/cmd/rockpaperscissors.go
+++ b/cmd/rockpaperscissors.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var secretMode bool
+
 // rootCmd represents the base command when called without any subcommands
 var rockPaperScissorsCmd = &cobra.Command{
 	Use:   "rockpaperscissors",
@@ -21,6 +23,11 @@ var rockPaperScissorsCmd = &cobra.Command{
 You can choose from rock, paper, or scissors. The computer will randomly choose its move and the winner will be determined based on the rules of the game.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input := userPrompt.New(os.Stdin, os.Stdout, os.Stderr)
-		rockpaperscissors.PlayGame(input)
+		rockpaperscissors.PlayGame(input, secretMode)
 	},
+}
+
+func init() {
+	rockPaperScissorsCmd.Flags().BoolVar(&secretMode, "spock", false, "Enable secret game mode")
+	rootCmd.AddCommand(rockPaperScissorsCmd)
 }

--- a/internal/rockpaperscissors/rockpaperscissors_test.go
+++ b/internal/rockpaperscissors/rockpaperscissors_test.go
@@ -149,6 +149,48 @@ func TestGame_getWinner(t *testing.T) {
 			secretMode:     true,
 			want:           "computer",
 		},
+		{
+			name:           "Secret mode - Draw - spock vs spock",
+			playerChoice:   "spock",
+			computerChoice: "spock",
+			secretMode:     true,
+			want:           "draw",
+		},
+		{
+			name:           "Secret mode - Player wins - lizard beats spock",
+			playerChoice:   "lizard",
+			computerChoice: "spock",
+			secretMode:     true,
+			want:           "player",
+		},
+		{
+			name:           "Secret mode - Computer wins - lizard beats spock",
+			playerChoice:   "lizard",
+			computerChoice: "rock",
+			secretMode:     true,
+			want:           "computer",
+		},
+		{
+			name:           "Secret mode - Draw - lizard vs lizard",
+			playerChoice:   "lizard",
+			computerChoice: "lizard",
+			secretMode:     true,
+			want:           "draw",
+		},
+		{
+			name:           "Secret mode - Player wins - spock beats scissors",
+			playerChoice:   "spock",
+			computerChoice: "scissors",
+			secretMode:     true,
+			want:           "player",
+		},
+		{
+			name:           "Secret mode - Computer wins - spock beats paper",
+			playerChoice:   "spock",
+			computerChoice: "paper",
+			secretMode:     true,
+			want:           "computer",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request introduces a new "secret mode" to the Rock Paper Scissors game, allowing additional moves (lizard and spock). The changes span the command-line interface, game logic, and unit tests.

Key changes include:

### Command-line Interface Enhancements:
* Added a new `--spock` flag to enable the secret game mode (`cmd/rockpaperscissors.go`). [[1]](diffhunk://#diff-e9a0334a3310969bd39456523655fab161d6e78356e1e3c87fea6849d8f1a11eR16-R17) [[2]](diffhunk://#diff-e9a0334a3310969bd39456523655fab161d6e78356e1e3c87fea6849d8f1a11eL24-R33)

### Game Logic Modifications:
* Introduced `secretOptions` and updated the `Game` struct to include a `SecretMode` field (`internal/rockpaperscissors/rockpaperscissors.go`). [[1]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9L12-R13) [[2]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9R36-R45)
* Updated the `NewGame` and `PlayGame` functions to handle secret mode (`internal/rockpaperscissors/rockpaperscissors.go`). [[1]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9R59) [[2]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9L146-R163)
* Modified the `getComputerChoice` and `getWinner` methods to support the new moves (`internal/rockpaperscissors/rockpaperscissors.go`). [[1]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9R85-R88) [[2]](diffhunk://#diff-8f60a901b6b58aada12977cff34a2028bb130ea985e2e88bec6731f1be68d3a9L91-R112)

### Unit Tests:
* Extended existing tests and added new ones to cover secret mode scenarios (`internal/rockpaperscissors/rockpaperscissors_test.go`). [[1]](diffhunk://#diff-b2b653c86c3cbd2b67afad4ae46cba7f467e650e84b572580ca685bf403b7239R5-R50) [[2]](diffhunk://#diff-b2b653c86c3cbd2b67afad4ae46cba7f467e650e84b572580ca685bf403b7239R59-R61) [[3]](diffhunk://#diff-b2b653c86c3cbd2b67afad4ae46cba7f467e650e84b572580ca685bf403b7239R72-R201) [[4]](diffhunk://#diff-b2b653c86c3cbd2b67afad4ae46cba7f467e650e84b572580ca685bf403b7239R215) [[5]](diffhunk://#diff-b2b653c86c3cbd2b67afad4ae46cba7f467e650e84b572580ca685bf403b7239L342-R469)